### PR TITLE
Allow empty/non existing file comparisons

### DIFF
--- a/src/main/java/org/jmeld/ui/BufferDiffPanel.java
+++ b/src/main/java/org/jmeld/ui/BufferDiffPanel.java
@@ -196,9 +196,6 @@ public class BufferDiffPanel extends AbstractContentPanel implements Configurati
             }
 
             title = bd.getShortName();
-            if (StringUtil.isEmpty(title)) {
-                continue;
-            }
 
             titles.add(title);
         }

--- a/src/main/java/org/jmeld/ui/FileComparison.java
+++ b/src/main/java/org/jmeld/ui/FileComparison.java
@@ -66,22 +66,12 @@ public class FileComparison extends SwingWorker<String, Object> {
     public String doInBackground() {
         try {
             if (diffNode == null) {
-                if (StringUtil.isEmpty(leftFile.getName())) {
-                    return "left filename is empty";
+                if (StringUtil.isEmpty(leftFile.getName()) || !leftFile.exists()) {
+                    leftFile = new File(leftFile.getName());
                 }
 
-                if (!leftFile.exists()) {
-                    return "left filename(" + leftFile.getAbsolutePath()
-                            + ") doesn't exist";
-                }
-
-                if (StringUtil.isEmpty(rightFile.getName())) {
-                    return "right filename is empty";
-                }
-
-                if (!rightFile.exists()) {
-                    return "right filename(" + rightFile.getAbsolutePath()
-                            + ") doesn't exist";
+                if (StringUtil.isEmpty(rightFile.getName()) || !rightFile.exists()) {
+                    rightFile = new File(rightFile.getName());
                 }
 
                 diffNode = JMDiffNodeFactory.create(leftFile.getName(), leftFile,

--- a/src/main/java/org/jmeld/ui/PanelDialog.java
+++ b/src/main/java/org/jmeld/ui/PanelDialog.java
@@ -196,7 +196,7 @@ public class PanelDialog
     label = new JLabel("Left");
     button = new JButton("Browse...");
     leftFileComboBox = new JComboBox();
-    leftFileComboBox.setEditable(false);
+    leftFileComboBox.setEditable(true);
     leftFileComboBox.addActionListener(getFileSelectAction());
     new ComboBoxPreference("LeftFile", leftFileComboBox);
 
@@ -211,7 +211,7 @@ public class PanelDialog
     button.setActionCommand(RIGHT_FILENAME);
     button.addActionListener(getFileBrowseAction());
     rightFileComboBox = new JComboBox();
-    rightFileComboBox.setEditable(false);
+    rightFileComboBox.setEditable(true);
     rightFileComboBox.addActionListener(getFileSelectAction());
     new ComboBoxPreference("RightFile", rightFileComboBox);
     panel.add(label, cc.xy(2, 4));
@@ -324,7 +324,7 @@ public class PanelDialog
     label = new JLabel("Left");
     button = new JButton("Browse...");
     leftDirectoryComboBox = new JComboBox();
-    leftDirectoryComboBox.setEditable(false);
+    leftDirectoryComboBox.setEditable(true);
     leftDirectoryComboBox.addActionListener(getDirectorySelectAction());
     new ComboBoxPreference("LeftDirectory", leftDirectoryComboBox);
 
@@ -339,7 +339,7 @@ public class PanelDialog
     button.setActionCommand(RIGHT_DIRECTORY);
     button.addActionListener(getDirectoryBrowseAction());
     rightDirectoryComboBox = new JComboBox();
-    rightDirectoryComboBox.setEditable(false);
+    rightDirectoryComboBox.setEditable(true);
     rightDirectoryComboBox.addActionListener(getDirectorySelectAction());
     new ComboBoxPreference("RightDirectory", rightDirectoryComboBox);
     panel.add(label, cc.xy(2, 4));
@@ -460,7 +460,7 @@ public class PanelDialog
     label = new JLabel("Directory");
     button = new JButton("Browse...");
     versionControlDirectoryComboBox = new JComboBox();
-    versionControlDirectoryComboBox.setEditable(false);
+    versionControlDirectoryComboBox.setEditable(true);
     versionControlDirectoryComboBox
         .addActionListener(getVersionControlDirectorySelectAction());
     new ComboBoxPreference("VersionControlDirectory",

--- a/src/main/java/org/jmeld/ui/text/FileDocument.java
+++ b/src/main/java/org/jmeld/ui/text/FileDocument.java
@@ -57,11 +57,6 @@ public class FileDocument
   {
     BufferedInputStream bis;
 
-    if (!file.isFile() || !file.canRead())
-    {
-      throw new JMeldException("Could not open file: " + file.getAbsolutePath());
-    }
-
     try
     {
       // Try to create a reader that has the right charset.
@@ -73,8 +68,7 @@ public class FileDocument
     }
     catch (Exception ex)
     {
-      throw new JMeldException("Could not create FileReader for : "
-                               + file.getName(), ex);
+      return new BufferedReader(new InputStreamReader(new ByteArrayInputStream("".getBytes())));
     }
   }
 

--- a/src/main/java/org/jmeld/util/node/FileNode.java
+++ b/src/main/java/org/jmeld/util/node/FileNode.java
@@ -59,11 +59,8 @@ public class FileNode
     if (document == null || isDocumentOutOfDate())
     {
       initialize();
-      if (exists())
-      {
-        document = new FileDocument(file);
-        fileLastModified = file.lastModified();
-      }
+      document = new FileDocument(file);
+      fileLastModified = file.lastModified();
     }
 
     return document;
@@ -79,7 +76,7 @@ public class FileNode
   {
     boolean outOfDate;
 
-    if (file == null || !exists())
+    if (file == null)
     {
       return false;
     }


### PR DESCRIPTION
This needs some feedback, but allow an empty File (with or without name) seems to work

**TODO**: Command line explicit definition to avoid single file to compare as version control

Fixes #56 