### PR TITLE
JMeld integration with SQuirreL SQL

### DIFF
--- a/src/main/java/org/jmeld/ui/BufferDiffPanel.java
+++ b/src/main/java/org/jmeld/ui/BufferDiffPanel.java
@@ -33,7 +33,6 @@ import org.jmeld.ui.text.AbstractBufferDocument;
 import org.jmeld.ui.text.BufferDocumentIF;
 import org.jmeld.ui.text.JMDocumentEvent;
 import org.jmeld.ui.tree.DiffTree;
-import org.jmeld.util.StringUtil;
 import org.jmeld.util.conf.ConfigurationListenerIF;
 import org.jmeld.util.node.BufferNode;
 import org.jmeld.util.node.JMDiffNode;
@@ -330,8 +329,10 @@ public class BufferDiffPanel extends AbstractContentPanel implements Configurati
 
         // panel for file1
         filePanel.add(new RevisionBar(this, filePanels[LEFT], true), cc.xy(2, 4));
-        if (mainPanel.SHOW_FILE_TOOLBAR_OPTION.isEnabled()) {
+        if (mainPanel.SHOW_FILE_SAVE_BAR_OPTION.isEnabled()) {
             filePanel.add(filePanels[LEFT].getSaveButton(), cc.xy(2, 2));
+        }
+        if (mainPanel.SHOW_FILE_LABEL_OPTION.isEnabled()) {
             filePanel.add(filePanels[LEFT].getFileLabel(), cc.xyw(4, 2, 3));
         }
         filePanel.add(filePanels[LEFT].getScrollPane(), cc.xyw(4, 4, 3));
@@ -344,11 +345,11 @@ public class BufferDiffPanel extends AbstractContentPanel implements Configurati
 
         // panel for file2
         filePanel.add(new RevisionBar(this, filePanels[RIGHT], false), cc.xy(12, 4));
-        if (mainPanel.SHOW_FILE_TOOLBAR_OPTION.isEnabled()) {
+        if (mainPanel.SHOW_FILE_LABEL_OPTION.isEnabled()) {
             filePanel.add(filePanels[RIGHT].getFileLabel(), cc.xyw(8, 2, 3));
         }
         filePanel.add(filePanels[RIGHT].getScrollPane(), cc.xyw(8, 4, 3));
-        if (mainPanel.SHOW_FILE_TOOLBAR_OPTION.isEnabled()) {
+        if (mainPanel.SHOW_FILE_SAVE_BAR_OPTION.isEnabled()) {
             filePanel.add(filePanels[RIGHT].getSaveButton(), cc.xy(12, 2));
         }
         if (mainPanel.SHOW_FILE_STATUSBAR_OPTION.isEnabled()) {

--- a/src/main/java/org/jmeld/ui/FilePanel.java
+++ b/src/main/java/org/jmeld/ui/FilePanel.java
@@ -146,7 +146,7 @@ public class FilePanel implements BufferDocumentChangeListenerIF, ConfigurationL
         return bufferDocument;
     }
 
-    JButton getSaveButton() {
+    public JButton getSaveButton() {
         return saveButton;
     }
 

--- a/src/main/java/org/jmeld/ui/JMeldComponent.java
+++ b/src/main/java/org/jmeld/ui/JMeldComponent.java
@@ -26,7 +26,8 @@ public class JMeldComponent extends Container {
         meldPanel.SHOW_TABBEDPANE_OPTION.disable();
         meldPanel.SHOW_TOOLBAR_OPTION.disable();
         meldPanel.SHOW_STATUSBAR_OPTION.disable();
-        meldPanel.SHOW_FILE_TOOLBAR_OPTION.disable();
+        meldPanel.SHOW_FILE_LABEL_OPTION.disable();
+        meldPanel.SHOW_FILE_SAVE_BAR_OPTION.disable();
         meldPanel.SHOW_FILE_STATUSBAR_OPTION.disable();
 
         setLayout(new BorderLayout());

--- a/src/main/java/org/jmeld/ui/JMeldPanel.java
+++ b/src/main/java/org/jmeld/ui/JMeldPanel.java
@@ -61,7 +61,8 @@ public class JMeldPanel extends JPanel implements ConfigurationListenerIF, Prope
     public final Option SHOW_TOOLBAR_OPTION;
     public final Option SHOW_STATUSBAR_OPTION;
     public final Option SHOW_TABBEDPANE_OPTION;
-    public final Option SHOW_FILE_TOOLBAR_OPTION;
+    public final Option SHOW_FILE_LABEL_OPTION;
+    public final Option SHOW_FILE_SAVE_BAR_OPTION;
     public final Option SHOW_FILE_STATUSBAR_OPTION;
     public final Option STANDALONE_INSTALLKEY_OPTION;
 
@@ -92,8 +93,9 @@ public class JMeldPanel extends JPanel implements ConfigurationListenerIF, Prope
         SHOW_TOOLBAR_OPTION = new Option(this, true);
         SHOW_STATUSBAR_OPTION = new Option(this, true);
         SHOW_TABBEDPANE_OPTION = new Option(this, true);
-        SHOW_FILE_TOOLBAR_OPTION = new Option(this, true);
+        SHOW_FILE_LABEL_OPTION = new Option(this, true);
         SHOW_FILE_STATUSBAR_OPTION = new Option(this, true);
+        SHOW_FILE_SAVE_BAR_OPTION = new Option(this, true);
         STANDALONE_INSTALLKEY_OPTION = new Option(this, false);
         actions = new Actions();
     }


### PR DESCRIPTION
- In JMeldPanel replaced SHOW_FILE_TOOLBAR_OPTION by SHOW_FILE_LABEL_OPTION and SHOW_FILE_SAVE_BAR_OPTION to be able to keep the save button and the gutter navigation while dropping the file name display.

- FilePanel.getSaveButton() was made public to be able to attach a listener to it.